### PR TITLE
Task Refactor: for eventual health check support amongst other things

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -193,8 +193,8 @@
 					"args": {
 						"$ref": "#/components/schemas/EnvArgs"
 					},
-					"running": {
-						"type": "boolean"
+					"state": {
+						"type": "string"
 					}
 				},
 				"required": [

--- a/openrpc.json
+++ b/openrpc.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"title": "ServiceRunner",
-		"version": "1.0.11"
+		"version": "1.0.12"
 	},
 	"methods": [
 		{

--- a/openrpc.json
+++ b/openrpc.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"title": "ServiceRunner",
-		"version": "1.0.10"
+		"version": "1.0.11"
 	},
 	"methods": [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -11576,6 +11576,11 @@
         "readable-stream": "^2.1.4"
       }
     },
+    "strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.11",
     "request": "^2.88.0",
     "rimraf": "^2.6.3",
+    "strict-event-emitter-types": "^2.0.0",
     "tar-fs": "^2.0.0",
     "typedoc": "^0.14.2",
     "winston": "^3.2.1",

--- a/src/generated-types/index.ts
+++ b/src/generated-types/index.ts
@@ -1,47 +1,47 @@
-export type RPCString = string;
-export type RPCBoolean = boolean;
-export interface InstalledService {
-  name?: RPCString;
-  version?: RPCString;
+export type StringWxzVcTo3 = string;
+export type BooleanQg3XFxa5 = boolean;
+export interface ObjectVZsrKceH {
+  name?: StringWxzVcTo3;
+  version?: StringWxzVcTo3;
   [k: string]: any;
 }
-export type InstalledServiceArray = InstalledService[];
-export type RPCStringArray = RPCString[];
-export interface SeqCommand {
-  cmd: RPCString;
-  args: RPCStringArray;
+export type ArrayKvcc3Slb = ObjectVZsrKceH[];
+export type ArrayFoEQPbEQ = StringWxzVcTo3[];
+export interface ObjectD8RkBGZG {
+  cmd: StringWxzVcTo3;
+  args: ArrayFoEQPbEQ;
   [k: string]: any;
 }
-export type SeqCommandArray = SeqCommand[];
-export interface Commands {
-  setup: SeqCommandArray;
-  start: RPCString;
-  stop: RPCString;
-  teardown: RPCString;
+export type ArrayQfe0DQgu = ObjectD8RkBGZG[];
+export interface ObjectHuetvW0J {
+  setup: ArrayQfe0DQgu;
+  start: StringWxzVcTo3;
+  stop: StringWxzVcTo3;
+  teardown: StringWxzVcTo3;
   [k: string]: any;
 }
-export interface EnvArgs {
-  start: RPCStringArray;
-  stop: RPCStringArray;
-  teardown: RPCStringArray;
+export interface ObjectHqcFUS7M {
+  start: ArrayFoEQPbEQ;
+  stop: ArrayFoEQPbEQ;
+  teardown: ArrayFoEQPbEQ;
   [k: string]: any;
 }
 /**
  * An object that describes an instance of a service
  */
-export interface TaskService {
-  env: RPCString;
-  rpcPort: RPCString;
-  name: RPCString;
-  version: RPCString;
-  path: RPCString;
-  commands: Commands;
-  args: EnvArgs;
-  running: RPCBoolean;
+export interface ObjectDLZvXzsu {
+  env: StringWxzVcTo3;
+  rpcPort: StringWxzVcTo3;
+  name: StringWxzVcTo3;
+  version: StringWxzVcTo3;
+  path: StringWxzVcTo3;
+  commands: ObjectHuetvW0J;
+  args: ObjectHqcFUS7M;
+  state?: StringWxzVcTo3;
   [k: string]: any;
 }
-export type TaskServiceArray = TaskService[];
-export type InstallService = (serviceName: RPCString, version: RPCString) => Promise<RPCBoolean>;
-export type ListInstalledServices = () => Promise<InstalledServiceArray>;
-export type ListRunningServices = () => Promise<TaskServiceArray>;
-export type StartService = (name: RPCString, version: RPCString, environment: RPCString) => Promise<TaskService>;
+export type ArrayZUy9Ik8E = ObjectDLZvXzsu[];
+export type InstallService = (serviceName: StringWxzVcTo3, version: StringWxzVcTo3) => Promise<BooleanQg3XFxa5>;
+export type ListInstalledServices = () => Promise<ArrayKvcc3Slb>;
+export type ListRunningServices = () => Promise<ArrayZUy9Ik8E>;
+export type StartService = (name: StringWxzVcTo3, version: StringWxzVcTo3, environment: StringWxzVcTo3) => Promise<ObjectDLZvXzsu>;

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,59 @@
+import {ITaskService, ActiveTaskService} from "./service";
+import EventEmitter from "events";
+import {Logger} from "winston";
+
+export type TaskEvent = LaunchTaskEvent | PendingTaskEvent | ConsoleTaskEvent | HealthTaskEvent | ErrorTaskEvent | ExitTaskEvent;
+
+export interface PendingTaskEvent {
+  name: "pending";
+  service: ITaskService;
+}
+
+export interface LaunchTaskEvent {
+  name: "launch";
+  service: ActiveTaskService;
+  logger: Logger;
+}
+
+export interface ConsoleTaskEvent {
+  name: "console";
+  stdout?: string;
+  stderr?: string;
+  logger: Logger;
+  service: ITaskService;
+}
+
+export interface HealthTaskEvent {
+  name: "health";
+  retries: number;
+  logger: Logger;
+  service: ActiveTaskService;
+  interval: NodeJS.Timeout;
+}
+
+export interface ErrorTaskEvent {
+  name: "error";
+  error: Error;
+  logger: Logger;
+  service: ITaskService;
+}
+
+export interface ExitTaskEvent {
+  name: "exit";
+  error?: Error;
+  code: number;
+  logger: Logger;
+  service: ActiveTaskService;
+}
+
+export class EventBus {
+  private static QUEUE_NAME = "INTERNAL_NOTIFICATIONS";
+  private bus: EventEmitter;
+  constructor(handler: (event: TaskEvent) => void, bus: EventEmitter = new EventEmitter()) {
+    this.bus = bus;
+    this.bus.addListener(EventBus.QUEUE_NAME, handler);
+  }
+  public emit(event: TaskEvent) {
+    this.bus.emit(EventBus.QUEUE_NAME, event);
+  }
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,20 +1,29 @@
 import {ITaskService, ActiveTaskService} from "./service";
 import EventEmitter from "events";
 import {Logger} from "winston";
-
+/*
+ TaskEvent describes the union type of all process management related tasks
+*/
 export type TaskEvent = LaunchTaskEvent | PendingTaskEvent | ConsoleTaskEvent | HealthTaskEvent | ErrorTaskEvent | ExitTaskEvent;
 
+/*
+ * PendingTaskEvent describes a task that has been created, and rendered, but has not been launched.
+*/
 export interface PendingTaskEvent {
   name: "pending";
   service: ITaskService;
 }
-
+/*
+ * LaunchTaskEvent describes an event that occurs when a task has been created, and template converted but has not been launched.
+*/
 export interface LaunchTaskEvent {
   name: "launch";
   service: ActiveTaskService;
   logger: Logger;
 }
-
+/*
+ * ConsoleTaskEvent describes an event that occurs when a task has output on stdout or stderr.
+ */
 export interface ConsoleTaskEvent {
   name: "console";
   stdout?: string;
@@ -22,7 +31,9 @@ export interface ConsoleTaskEvent {
   logger: Logger;
   service: ITaskService;
 }
-
+/*
+ * HealthTaskEvent describes an event that occurs when a healthcheck is required to be prefored.
+ */
 export interface HealthTaskEvent {
   name: "health";
   retries: number;
@@ -30,14 +41,18 @@ export interface HealthTaskEvent {
   service: ActiveTaskService;
   interval: NodeJS.Timeout;
 }
-
+/*
+ * ErrorTaskEvent describes an event that occurs when a fatal error has occured with a task that is not related to an exit.
+ */
 export interface ErrorTaskEvent {
   name: "error";
   error: Error;
   logger: Logger;
   service: ITaskService;
 }
-
+/*
+ * ExitTaskEvent describes an event that occurs when a tasks exits.
+ */
 export interface ExitTaskEvent {
   name: "exit";
   error?: Error;
@@ -45,7 +60,11 @@ export interface ExitTaskEvent {
   logger: Logger;
   service: ActiveTaskService;
 }
-
+/**
+ * EventBus is a message bus for internal notifications related to process management
+ * The intent is that EventBus is utilized by TaskProcessManager to handle process state transitions
+ * and is the only source of a process state transition.
+ */
 export class EventBus {
   private static QUEUE_NAME = "INTERNAL_NOTIFICATIONS";
   private bus: EventEmitter;

--- a/src/lib/service-runner-schema.json
+++ b/src/lib/service-runner-schema.json
@@ -16,6 +16,23 @@
         "type": "string"
       }
     },
+    "health": {
+      "type": "object",
+      "port": {
+        "type": "string"
+      },
+      "interval": {
+        "type": "number"
+      },
+      "retries": {
+        "type": "number"
+      },
+      "proto": {
+        "type": "string",
+        "oneOf":["udp","tcp"]
+      },
+      "required":["interval", "retries", "port", "proto"]
+    },
     "commandArgs": {
         "start": {
           "$ref": "#/definitions/args"
@@ -78,6 +95,9 @@
         },
         "args": {
           "$ref": "#/definitions/commandArgs"
+        },
+        "health": {
+          "$ref": "#/definitions/health"
         }
       },
       "required": ["name"]

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -1,3 +1,6 @@
+import { StrictEventEmitter } from "strict-event-emitter-types";
+import { EventEmitter } from "events";
+
 export interface IService {
   name: string;
   rpcPort: string;
@@ -6,10 +9,19 @@ export interface IService {
   commands: ICommands;
   assets: string[];
 }
+
+export interface IHealth {
+  port: string;
+  proto: string;
+  retries: number;
+  interval: number;
+}
+
 export interface IConfig {
   "$schema": string;
   services: IServiceConfig[];
 }
+
 export interface IServiceConfig {
   name: string;
   rpcPort: string;
@@ -30,6 +42,7 @@ export interface IServiceOSConfig {
 export interface IServiceEnv {
   name: string;
   args: IEnvArgs;
+  health?: IHealth;
 }
 
 export interface IEnvArgs {
@@ -50,3 +63,29 @@ export interface ISequenceCmd {
   cmd: string;
   args: string[];
 }
+
+export interface TaskNotificationEvents {
+  launched: (service: ITaskService) => void;
+  terminated: (service: ITaskService) => void;
+  pending: (service: ActiveTaskService) => void;
+}
+
+export interface ITaskService {
+  env: string;
+  rpcPort: string;
+  name: string;
+  version: string;
+  path: string;
+  commands: ICommands;
+  health?: IHealth;
+  args: IEnvArgs;
+  notifications: StrictEventEmitter<EventEmitter, TaskNotificationEvents>;
+}
+
+export interface ActiveTaskService extends ITaskService {
+  state: TaskState;
+  pid?: number;
+}
+
+export type TaskState = "running" | "stopped" | "pending";
+export type TaskStatus = "spec" | TaskState;

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -64,12 +64,17 @@ export interface ISequenceCmd {
   args: string[];
 }
 
+/**
+ * TaskNotifcationEvents are a set of service specific events that can be subscribed to.
+ */
 export interface TaskNotificationEvents {
   launched: (service: ITaskService) => void;
   terminated: (service: ITaskService) => void;
   pending: (service: ActiveTaskService) => void;
 }
-
+/*
+ * ITaskService describes a service description that can be used to render a process, then subsequently launch a process.
+*/
 export interface ITaskService {
   env: string;
   rpcPort: string;
@@ -81,7 +86,9 @@ export interface ITaskService {
   args: IEnvArgs;
   notifications: StrictEventEmitter<EventEmitter, TaskNotificationEvents>;
 }
-
+/**
+ * ActiveTaskService describes a service description that is currently running, including its resolved parameters if templated parameters were used.
+ */
 export interface ActiveTaskService extends ITaskService {
   state: TaskState;
   pid?: number;

--- a/src/lib/serviceTemplate.ts
+++ b/src/lib/serviceTemplate.ts
@@ -1,0 +1,65 @@
+/**
+ * The serviceTemplate module handles resolving any templated
+ * service configuration, allocating dynamic ports for services.
+ */
+import { makeLogger } from "./logging";
+import { template } from "lodash";
+import {ITaskService, ActiveTaskService} from "./service";
+import {ISequenceCmd, IHealth } from "./service";
+import { getFreePorts } from "./util";
+
+const logger = makeLogger("ServiceRunner", "RenderServiceTemplate");
+
+/**
+ * Starts an installed service using the service configuration and manifest entry, and
+ * returns service configuration information.
+ *
+ *
+ * @param service - Templated spec of the service
+ * @returns The rendered version of the service configuration
+ */
+export async function renderService(service: ITaskService): Promise<ActiveTaskService> {
+  logger.debug(`rendering service config for ${service.name}`);
+  const ports = await getFreePorts();
+  const SERVICE_DIR = service.path;
+  const dynamicVar = { ...ports, SERVICE_DIR };
+  const renderArgs = (cmds: string[]) => cmds.map((cmd) => template(cmd)({ ...dynamicVar }));
+  const renderCmd = (cmd: string) => template(cmd)({ ...dynamicVar });
+  const renderSequenceCmd = (seqCmds: ISequenceCmd[]) => seqCmds.map((cmd) => {
+    return {
+      args: renderArgs(cmd.args),
+      cmd: renderCmd(cmd.cmd),
+    };
+  });
+
+  const command = {
+    setup: renderSequenceCmd(service.commands.setup),
+    start: renderCmd(service.commands.start),
+    stop: renderCmd(service.commands.stop),
+    teardown: renderCmd(service.commands.teardown),
+  };
+
+  const args = {
+    start: renderArgs(service.args.start),
+    stop: renderArgs(service.args.stop),
+    teardown: renderArgs(service.args.teardown),
+  };
+  let health: IHealth | undefined;
+  if (service.health) {
+    health = {
+      ...service.health,
+      port: renderCmd(service.health.port),
+    };
+  }
+
+  const rpcPort = template(service.rpcPort)({ ...dynamicVar });
+  logger.debug(`rendered service config for ${service.name}`);
+  return {
+    ...service,
+    commands: command,
+    rpcPort,
+    health,
+    state: "pending",
+    args,
+  };
+}

--- a/src/lib/task.test.ts
+++ b/src/lib/task.test.ts
@@ -10,6 +10,7 @@ import http from "http";
 import { IServiceConfig } from "./service";
 import { getOS, OSTypes } from "./util";
 import { Installer } from "./installer";
+import { kill } from "process";
 const rmDir = promisify(rimraf);
 describe("TaskManager", () => {
   let repoDir: string;
@@ -53,6 +54,8 @@ describe("TaskManager", () => {
       expect(serviceConfig).toBeDefined();
       await new Promise((resolve) => {
         setTimeout(() => {
+          const pid = serviceConfig.pid;
+          if (pid) { kill(pid); }
           resolve();
         }, 3000);
       });

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -64,7 +64,7 @@ export class TaskManager {
     return new Promise((resolve) => {
       logger.debug(`Launching ${taskService.name} in ${taskService.env}`);
       // NOTE notification listener may need to be removed pending downstream behavior
-      taskService.notifications.on("launched", (service) => {
+      taskService.notifications.once("launched", (service) => {
         logger.debug(`Launched ${service.name} in ${service.env}`);
         resolve(service);
       });

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -3,30 +3,21 @@
  * launched alive, until the ServiceRunner process is killed.
  *
  * TaskManager exposes the public interfaces for starting and listing active services
- *
- * TaskProcessManager keeps a record of processes launched, and processes installed. In addition,
- * prior to launching the services, the TaskProcessManager handles resolving any templated
- * service configuration, allocating dynamic ports for services.
  */
 import { Repo } from "./repo";
 import { Config } from "./config";
-import { getOS, getAvailableTCPPort, getAvailableUDPPort } from "./util";
-import { spawn } from "child_process";
-import { ICommands, IServiceEnv, IEnvArgs, ISequenceCmd } from "./service";
+import { getOS } from "./util";
+import { TaskProcessManager } from "./taskProcessManager";
+import {
+  IServiceEnv,
+  ActiveTaskService,
+} from "./service";
 import { makeLogger } from "./logging";
-import { template } from "lodash";
+import { EventEmitter } from "events";
 export interface ITaskOptions {
   intervalMS: number;
 }
-// Allows for 3 dynamic TCP Ports and 3 dynamic UDP Ports
-interface IDynamicPorts {
-  DYNAMIC_TCP_PORT_1: number;
-  DYNAMIC_TCP_PORT_2: number;
-  DYNAMIC_TCP_PORT_3: number;
-  DYNAMIC_UDP_PORT_1: number;
-  DYNAMIC_UDP_PORT_2: number;
-  DYNAMIC_UDP_PORT_3: number;
-}
+
 const logger = makeLogger("ServiceRunner", "TaskManager");
 export class TaskManager {
 
@@ -52,7 +43,7 @@ export class TaskManager {
    * @param env - Environment
    * @returns The rendered version of the service configuration
    */
-  public async startService(serviceName: string, version: string, env: string) {
+  public async startService(serviceName: string, version: string, env: string): Promise<ActiveTaskService> {
 
     const serviceEntry = await this.repo.getServiceEntry(serviceName, version);
     if (serviceEntry === undefined) { throw new Error("Service does not exists in repo"); }
@@ -66,10 +57,20 @@ export class TaskManager {
       args,
       commands,
       path: serviceEntry.path,
-      running: false,
       rpcPort,
+      notifications: new EventEmitter(),
     };
-    return this.manager.launchTask(taskService);
+
+    return new Promise((resolve) => {
+      logger.debug(`Launching ${taskService.name} in ${taskService.env}`);
+      // NOTE notification listener may need to be removed pending downstream behavior
+      taskService.notifications.on("launched", (service) => {
+        logger.debug(`Launched ${service.name} in ${service.env}`);
+        resolve(service);
+      });
+      this.manager.launchTask(taskService);
+    });
+
   }
   /**
    * Returns a list of currently active services
@@ -77,149 +78,13 @@ export class TaskManager {
    * @returns The active list of services
    */
   public listActiveServices() {
-    const services: ITaskService[] = [];
-    this.manager.activeTaskMap.forEach((v) => {
+    const services: ActiveTaskService[] = [];
+    logger.debug("Listing active services");
+    this.manager.activeTaskMap.forEach((v: ActiveTaskService) => {
 
-      const { running } = v;
-      if (running) { services.push(v); }
+      const { state } = v;
+      if (state === "running") { services.push(v); }
     });
     return services;
   }
-}
-
-interface ITaskService {
-  env: string;
-  rpcPort: string;
-  name: string;
-  version: string;
-  path: string;
-  commands: ICommands;
-  args: IEnvArgs;
-  running: boolean;
-}
-
-export class TaskProcessManager {
-
-  public taskMap: Map<string, ITaskService>;
-  public activeTaskMap: Map<string, ITaskService>;
-  constructor() {
-    this.taskMap = new Map<string, ITaskService>();
-    this.activeTaskMap = new Map<string, ITaskService>();
-  }
-
-  /**
-   * Launches a service, writing the service to an in memory map of active and templated processes.
-   * It spawns new tasks, and catches errors and SIGTERM signals to then re spawn itself. It
-   * returns a fully rendered config
-   *
-   * @param service - Configuration for a templated service
-   * @returns The rendered configuration for a service
-   */
-  public async launchTask(service: ITaskService): Promise<ITaskService> {
-
-    this.addTask(service, this.taskMap);
-    const renderedService = await this.renderCommands(service);
-    this.addTask(renderedService, this.activeTaskMap);
-    // NOTE makes assumption that setup processes exit prior to running the main process
-    await this.spawnSeqCommands(renderedService.commands.setup);
-    const child = spawn(`${renderedService.commands.start}`, renderedService.args.start);
-    const childLogger = makeLogger(service.name, "Active Task");
-    child.stdout.on("data", (data) => {
-      childLogger.debug(`stdout: ${data}`);
-    });
-
-    child.stderr.on("data", (data) => {
-      childLogger.error(`stderr: ${data}`);
-    });
-
-    child.on("close", (code) => {
-      childLogger.debug(`child process exited with code ${code}`);
-      this.launchTask(service);
-    });
-    child.on("error", (err) => {
-      childLogger.error(`${service.name}: child process exited with err ${err}`);
-      this.launchTask(service);
-    });
-    service.running = true;
-    renderedService.running = true;
-    logger.info(`Launched service with ${JSON.stringify(renderedService)}`);
-    return renderedService;
-  }
-
-  // NOTE makes assumption that setup tasks don't fail
-  private async spawnSeqCommands(cmds: ISequenceCmd[]) {
-    cmds.forEach(async (cmd) => {
-      await new Promise((resolve) => {
-        const child = spawn(cmd.cmd, cmd.args);
-        child.on("error", (err) => {
-          throw err;
-        });
-        child.on("exit", () => {
-          resolve();
-        });
-      });
-    });
-  }
-
-  private async getFreePorts(): Promise<IDynamicPorts> {
-    const tcpPorts = [1, 2, 3].map(() => getAvailableTCPPort());
-    const udpPorts = [1, 2, 3].map(() => getAvailableUDPPort());
-
-    const availPorts = await Promise.all([...tcpPorts, ...udpPorts]) as number[];
-    return {
-      DYNAMIC_TCP_PORT_1: availPorts[1],
-      DYNAMIC_TCP_PORT_2: availPorts[2],
-      DYNAMIC_TCP_PORT_3: availPorts[3],
-      DYNAMIC_UDP_PORT_1: availPorts[4],
-      DYNAMIC_UDP_PORT_2: availPorts[5],
-      DYNAMIC_UDP_PORT_3: availPorts[6],
-    };
-  }
-
-  private addTask(service: ITaskService, taskMap: Map<string, ITaskService>) {
-    const hash = this.taskHash(service);
-    if (taskMap.has(hash)) { return; }
-    taskMap.set(hash, service);
-  }
-
-  private taskHash(service: ITaskService): string {
-    return `${service.name}_${service.version}_${service.env}`;
-  }
-  private async renderCommands(service: ITaskService): Promise<ITaskService> {
-    // @ts-ignore these are use ambiently by the eval
-    const ports = await this.getFreePorts();
-    // @ts-ignore is ambiently utilized by template
-    const SERVICE_DIR = service.path;
-    const dynamicVar = { ...ports, SERVICE_DIR };
-    const renderArgs = (cmds: string[]) => cmds.map((cmd) => template(cmd)({ ...dynamicVar }));
-    const renderCmd = (cmd: string) => template(cmd)({ ...dynamicVar });
-    const renderSequenceCmd = (seqCmds: ISequenceCmd[]) => seqCmds.map((cmd) => {
-      return {
-        args: renderArgs(cmd.args),
-        cmd: renderCmd(cmd.cmd),
-      };
-    });
-
-    const command = {
-      setup: renderSequenceCmd(service.commands.setup),
-      start: renderCmd(service.commands.start),
-      stop: renderCmd(service.commands.stop),
-      teardown: renderCmd(service.commands.teardown),
-    };
-
-    const args = {
-      start: renderArgs(service.args.start),
-      stop: renderArgs(service.args.stop),
-      teardown: renderArgs(service.args.teardown),
-    };
-
-    const rpcPort = template(service.rpcPort)({ ...dynamicVar });
-    return {
-      ...service,
-      commands: command,
-      rpcPort,
-      args,
-    };
-  }
-
 }

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -19,6 +19,9 @@ export interface ITaskOptions {
 }
 
 const logger = makeLogger("ServiceRunner", "TaskManager");
+/*
+ * TaskManager provide a high level interface, to launch and list running services from.
+*/
 export class TaskManager {
 
   public repo: Repo;
@@ -63,7 +66,6 @@ export class TaskManager {
 
     return new Promise((resolve) => {
       logger.debug(`Launching ${taskService.name} in ${taskService.env}`);
-      // NOTE notification listener may need to be removed pending downstream behavior
       taskService.notifications.once("launched", (service) => {
         logger.debug(`Launched ${service.name} in ${service.env}`);
         resolve(service);

--- a/src/lib/taskProcessManager.ts
+++ b/src/lib/taskProcessManager.ts
@@ -1,0 +1,172 @@
+/**
+ *  TaskProcessManager launchs and manage services, keeping services that have been
+ *  launched alive, until the ServiceRunner process is killed explictly.
+ *  TaskProcessManager keeps a record of processes launched, and processes installed. It creates a unidirectional flow for
+ *  process run by service runner. It acts as a sink for processes that are being launched, and includes providing hooks for
+ *  downstream consumers to subscribe to process level events.
+ */
+import { ITaskService, ActiveTaskService, IHealth, ISequenceCmd, TaskStatus } from "./service";
+import * as events from "./events";
+import { spawn } from "child_process";
+import { renderService } from "./serviceTemplate";
+import { makeLogger } from "./logging";
+
+const logger = makeLogger("ServiceRunner", "TaskProcessManager");
+
+export class TaskProcessManager {
+
+  public taskMap: Map<string, ITaskService>;
+  public activeTaskMap: Map<string, ActiveTaskService>;
+  private notifications: events.EventBus;
+  constructor() {
+    this.taskMap = new Map<string, ITaskService>();
+    this.activeTaskMap = new Map<string, ActiveTaskService>();
+    this.notifications = new events.EventBus(this.processTask.bind(this));
+  }
+
+  /**
+   * Launches a service, writing the service to an in memory map of active and templated processes.
+   * It spawns new tasks, and catches errors and SIGTERM signals to then re spawn itself. It
+   * returns a fully rendered config
+   *
+   *
+   * @param service - Configuration for a templated service
+   * @returns The rendered configuration for a service
+   */
+  public async launchTask(service: ITaskService): Promise<ITaskService> {
+
+    return new Promise((resolve) => {
+      const pendingTask: events.PendingTaskEvent = { name: "pending", service };
+      this.notifications.emit(pendingTask);
+      service.notifications.on("launched", (svc) => {
+        resolve(svc);
+      });
+    });
+  }
+
+  private handleConsoleEvent(event: events.ConsoleTaskEvent) {
+    if (event.stderr) {
+      logger.error(`stderr: ${event.stderr}`);
+    }
+    if (event.stdout) {
+      logger.debug(`stdout: ${event.stdout}`);
+    }
+  }
+
+  private handleExitEvent(event: events.ExitTaskEvent) {
+    const {service, error} = event;
+    const exitMsg = `${service.name}: child process exited`;
+    this.setTask(service, "stopped");
+    if (error) {
+      event.logger.error(`${exitMsg} with err ${error}`);
+      return;
+    }
+    event.logger.error(`${exitMsg}`);
+  }
+
+  private async handleLaunchEvent(event: events.LaunchTaskEvent) {
+    const { service } = event;
+    await this.spawnSeqCommands(service.commands.setup);
+    const child = spawn(`${service.commands.start}`, service.args.start);
+    const childLogger = event.logger;
+    child.stdout.on("data", (data) => {
+      this.notifications.emit({ name: "console", stdout: data, logger: childLogger, service });
+    });
+
+    child.stderr.on("data", (data) => {
+      this.notifications.emit({ name: "console", stderr: data, logger: childLogger, service });
+    });
+
+    child.on("close", (code) => {
+      this.notifications.emit({ name: "exit", code, logger: childLogger, service });
+    });
+    child.on("error", (err) => {
+      this.notifications.emit({ name: "exit", error: err, code: -1, logger: childLogger, service });
+    });
+    logger.info(`Launched service with ${JSON.stringify(service)}`);
+
+    service.pid = child.pid;
+    this.setTask(service, "running");
+    service.notifications.emit("launched", service);
+  }
+
+  private handleHealthEvent(event: events.HealthTaskEvent) {
+    // TODO
+  }
+
+  private async processTask(event: events.TaskEvent) {
+    switch (event.name) {
+      case "console":
+        this.handleConsoleEvent(event);
+        return;
+      case "error":
+        throw new Error(`Could not handle task error ${event.error}`);
+      case "exit":
+        this.handleExitEvent(event);
+        return;
+      case "pending":
+        await this.handlePendingEvent(event);
+        return;
+      case "launch":
+        await this.handleLaunchEvent(event);
+        return;
+      case "health":
+        this.handleHealthEvent(event);
+        return;
+    }
+  }
+
+  private async handlePendingEvent(event: events.PendingTaskEvent) {
+    const { service } = event;
+    await this.setTask(service, "spec");
+    const renderedService = await renderService(service);
+    this.setTask(renderedService, "pending");
+    const serviceLogger = makeLogger(renderedService.name, "Child Task");
+    this.notifications.emit({ service: renderedService, name: "launch", logger: serviceLogger });
+  }
+
+  private async spawnSeqCommands(cmds: ISequenceCmd[]) {
+    cmds.forEach(async (cmd) => {
+      await new Promise((resolve) => {
+        const child = spawn(cmd.cmd, cmd.args);
+        child.on("error", (err) => {
+          throw err;
+        });
+        child.on("exit", () => {
+          resolve();
+        });
+      });
+    });
+  }
+
+private setTask(service: ITaskService, status: TaskStatus) {
+  if (status === "spec") {
+    this.addTaskSpec(service);
+    return;
+  }
+  const activeService = service as ActiveTaskService;
+  activeService.state = status;
+  this.addActiveTaskSpec(activeService);
+  return;
+}
+
+  private addTaskSpec(service: ITaskService) {
+    const hash = this.taskHash(service);
+    if (this.taskMap.has(hash)) {
+      return;
+    }
+    this.taskMap.set(hash, service);
+  }
+
+  private addActiveTaskSpec(service: ActiveTaskService) {
+    const hash = this.taskHash(service);
+    if (this.activeTaskMap.has(hash) === false) {
+      this.taskMap.set(hash, service);
+      return;
+    }
+  }
+
+  private taskHash(service: ITaskService): string {
+    return `${service.name}_${service.version}_${service.env}`;
+  }
+}

--- a/src/lib/taskProcessManager.ts
+++ b/src/lib/taskProcessManager.ts
@@ -38,7 +38,7 @@ export class TaskProcessManager {
     return new Promise((resolve) => {
       const pendingTask: events.PendingTaskEvent = { name: "pending", service };
       this.notifications.emit(pendingTask);
-      service.notifications.on("launched", (svc) => {
+      service.notifications.once("launched", (svc) => {
         resolve(svc);
       });
     });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -15,6 +15,36 @@ const logger = makeLogger("ServiceRunner", "Util");
 const fsMkdir = promisify(mkdir);
 const openZip = promisify(yauzl.open) as (path: string, options: yauzl.Options) => Promise<ZipFile | undefined>;
 
+interface IDynamicPorts {
+  DYNAMIC_TCP_PORT_1: number;
+  DYNAMIC_TCP_PORT_2: number;
+  DYNAMIC_TCP_PORT_3: number;
+  DYNAMIC_UDP_PORT_1: number;
+  DYNAMIC_UDP_PORT_2: number;
+  DYNAMIC_UDP_PORT_3: number;
+}
+
+// Note this might be problematic if there are collisions
+/**
+ * Returns a set of TCP and UDP Ports.
+ *
+ *
+ * @returns a set of free TCP and UDP Ports
+ */
+export async function getFreePorts(): Promise < IDynamicPorts > {
+  const tcpPorts = [1, 2, 3].map(() => getAvailableTCPPort());
+  const udpPorts = [1, 2, 3].map(() => getAvailableUDPPort());
+
+  const availPorts = await Promise.all([...tcpPorts, ...udpPorts]) as number[];
+  return {
+    DYNAMIC_TCP_PORT_1: availPorts[1],
+    DYNAMIC_TCP_PORT_2: availPorts[2],
+    DYNAMIC_TCP_PORT_3: availPorts[3],
+    DYNAMIC_UDP_PORT_1: availPorts[4],
+    DYNAMIC_UDP_PORT_2: availPorts[5],
+    DYNAMIC_UDP_PORT_3: availPorts[6],
+  };
+}
 // Note this might be problematic if executed serially
 /**
  * Returns a free TCP Port.

--- a/src/service-runner-config.json
+++ b/src/service-runner-config.json
@@ -5,8 +5,7 @@
       "name": "multi-geth",
       "rpcPort": "${DYNAMIC_TCP_PORT_1}",
       "version": "1.9.0",
-      "environments": [
-        {
+      "environments": [{
           "name": "mainnet",
           "args": {
             "start": [
@@ -21,7 +20,13 @@
             ],
             "stop": [],
             "teardown": []
-          }
+          },
+          "health": {
+           "interval": 5000, 
+           "retries": 2,
+           "port": "${DYNAMIC_TCP_PORT_1}",
+           "proto": "tcp"
+           }
         },
         {
           "name": "kotti",
@@ -56,7 +61,13 @@
             ],
             "stop": [],
             "teardown": []
-          }
+          },
+          "health": {
+           "interval": 5000, 
+           "retries": 2,
+           "port": "${DYNAMIC_TCP_PORT_1}",
+           "proto": "tcp"
+           }
         },
         {
           "name": "goerli",
@@ -73,7 +84,13 @@
             ],
             "stop": [],
             "teardown": []
-          }
+          },
+          "health": {
+           "interval": 5000, 
+           "retries": 2,
+           "port": "${DYNAMIC_TCP_PORT_1}",
+           "proto": "tcp"
+           }
         },
         {
           "name": "rinkeby",
@@ -90,7 +107,13 @@
             ],
             "stop": [],
             "teardown": []
-          }
+          },
+          "health": {
+           "interval": 5000, 
+           "retries": 2,
+           "port": "${DYNAMIC_TCP_PORT_1}",
+           "proto": "tcp"
+           }
         }
       ],
       "os": {


### PR DESCRIPTION
This PR is really a 1 of 2. I was working on healthchecks when, it struck me that the task management side of what we're doing really needed a little TLC. I refactored the tasks to managed in a more unidirectional way, where service state should only mutate in on place, and you can have many producers of service state transitions, but ultimately only on consumer that can mutate state( not entirely true yet but the general framework is there in processTask).  

In additional to this reorg, I also added hooks for a typed service notifications. As we build on top of this, if we build a proxy for services or want to support more complicated use cases we might need to be able to subscribe to service specific events ("launched", "terminated","pending", "restarted", "health-failure"). Which as the producer of this server side we can figure out what slice of this data we might want to provide to consuming applications.

Imagine that we have service runner provides a way for consuming clients to use websockets to subscribe to events about services they've launched or are using. I.e. if a service they're using crashed they can receive an event about that and do something useful. 

I think this refactor will be useful going forward as well internally, as we think about possibly providing load/proxying capabilities.

let me know what you think. There is a small bleed here, as it aslo provides some inconsequential scaffolding for health checks. These were minor enough that it seemed ok to let these remain in this PR.